### PR TITLE
Issue #3: Fix coverage reporting

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,6 +1,7 @@
 {
   "exclude": [
-    "./dist",
-    "./helpers"
-  ]
+    "dist",
+    "helpers"
+  ],
+  "all": true
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build": "scripty",
     "lint-staged": "lint-staged",
     "test": "ava",
-    "cov": "nyc --all npm test",
+    "cov": "nyc npm test",
     "flow": "flow",
     "lint": "scripty"
   }


### PR DESCRIPTION
Allows the `dist` & `helpers` directories to be excluded from coverage reporting, resulting in more accurate percentages